### PR TITLE
Fix Prisma Client generation for Vercel deployment

### DIFF
--- a/vetelohace-SOLUCIONADO/package.json
+++ b/vetelohace-SOLUCIONADO/package.json
@@ -3,9 +3,10 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build", 
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
+    "postinstall": "prisma generate",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:seed": "tsx --require dotenv/config scripts/seed.ts",


### PR DESCRIPTION
## Problem
The application was failing to build on Vercel with the following error:
```
Prisma has detected that this project was built on Vercel, which caches dependencies. 
This leads to an outdated Prisma Client because Prisma's auto-generation isn't triggered.
```

The build was failing at the "Collecting page data" step when trying to initialize Prisma Client for the NextAuth route.

## Solution
This PR adds two critical changes to `package.json`:

1. **Added `postinstall` script**: Automatically runs `prisma generate` after `npm install`
   - This ensures Prisma Client is generated whenever dependencies are installed
   - Vercel runs this script during the build process

2. **Updated `build` script**: Now runs `prisma generate && next build`
   - Provides an additional safeguard to ensure Prisma Client is generated before building
   - Ensures the build process always has an up-to-date Prisma Client

## Changes
- Modified `vetelohace-SOLUCIONADO/package.json`:
  - Added: `"postinstall": "prisma generate"`
  - Updated: `"build": "prisma generate && next build"`

## Testing
After merging this PR, Vercel will:
1. Install dependencies
2. Run the `postinstall` script (generating Prisma Client)
3. Run the `build` script (which also ensures Prisma Client is generated)
4. Successfully build and deploy the application

This fix follows Prisma's official recommendation for Vercel deployments.